### PR TITLE
Release the snap if it's expiring tomorrow.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -34,6 +34,13 @@ jobs:
           export ACTION_URL
 
           printf %s "$FF_CHR_LLVM" > "$HOME/snap/surl/common/ff-chr-llvm.surl"
+          ln "$HOME/snap/surl/common/ff-chr-llvm.surl" \
+             "$HOME/snap/surl/common/firefox.surl"
+          ln "$HOME/snap/surl/common/ff-chr-llvm.surl" \
+             "$HOME/snap/surl/common/chromium.surl"
+          ln "$HOME/snap/surl/common/ff-chr-llvm.surl" \
+             "$HOME/snap/surl/common/llvm-chromium.surl"
+
           printf %s "$SNAP_STORE" > "$HOME/snap/surl/common/snap-store.surl"
           printf %s "$SNAPD_DESKTOP_INTEGRATION" > "$HOME/snap/surl/common/snapd-desktop-integration.surl"
           ./snap-expire watched-snaps

--- a/README
+++ b/README
@@ -1,5 +1,6 @@
 This repository's CI will daily broadcast snaps branches soon to expire in
-Mattermost's ~desktop-team-eng channel.
+Mattermost's ~desktop-team-eng channel. If the snap will expire in the
+following day, it will itself refresh the channel without human intervention.
 
 As the Snap Store considers that information is private data, to enroll
 your snaps here, you first need to gather authorization data.
@@ -8,15 +9,18 @@ The recipe to enroll your snaps is:
 
 * Locally, "snap install surl".
 * Locally,
-  $ surl -e {your@snapstore.email} -p package_access -s production --snap {snap} -a {auth-file}
+
+    surl -e {your@snapstore.email} -p package_release -p package_access \
+         -s production --snap {snap} -a {snap}
+
   You will be asked your password and 2FA.
   This causes your authentication identifier file {auth-file}.surl, used in next
   step, to be created.
-  You can provide multiple --snap arguments if you prefer to generate an
-  unified {auth-file}.surl.
+  You can opt-out of the "refresh without human intervention" part of this
+  automation by not giving "-p package_release".
 * Copy the contents of ~/snap/surl/common/{auth-file}.surl to a new repository
   secret in https://github.com/canonical/snap-expire/settings/secrets/actions.
-* Add your printf line and env line to .github/workflows/ci.yaml.
+* Add your env and printf lines to .github/workflows/ci.yaml.
 * Append your entry to watched-snaps, whose format is
 
   {snap} {expire-in} {auth-file} [{mattermost-ids}]
@@ -26,3 +30,5 @@ The recipe to enroll your snaps is:
                will expire in {expire-in} days.
   {mattermost-ids}: List of Mattermost IDs to ping (separated by whatever
                     punctuation, but not spaces, e.g. person1:person2,person3).
+
+* Yes, I do regret writing this as a shell script. Passing around text is no fun.

--- a/snap-expire
+++ b/snap-expire
@@ -75,24 +75,8 @@ broadcast_debug(){
 # "llvm-chromium\t2026-03-26T00:00:00Z\tarmhf\tlatest/stable/core22\t65"
 #Where $1 is the snap, $2 its expiration, $(NF-1) as channel, $NF as revision
 rerelease_snaps_expiring_tomorrow(){
-    awk -v today="$(date -u +%FT%TZ)" '
-        {
-            gsub("\\\\t", " ")
-            gsub(/"/, "")
-        }
-        # Not a valid revision number? Ignore line.
-        $NF !~ /^[0123456789]+$/{
-           print("Line >>", $NF, "<< does not have a valid revision number, skipping")
-           next
-        }
-        {
-           "datediff -f %d " today " " $2 | getline daysTilExpires
-           if (daysTilExpires <= 25) {
-               # TODO: Remove echo and replace 25 by 1 once convinced this really works well.
-               system("echo snapcraft release " $1 " " $NF " " $(NF-1))
-           }
-        }
- '
+    url="https://dashboard.snapcraft.io/dev/api/snap-release/"
+    awk -v today="$(date -u +%FT%TZ)" -v url="$url" -f snap-releaser.awk
 }
 
 require surl jq curl datediff awk

--- a/snap-releaser.awk
+++ b/snap-releaser.awk
@@ -1,0 +1,16 @@
+{
+    gsub("\\\\t", " ")
+    gsub(/"/, "")
+}
+# Not a valid revision number? Ignore line.
+$NF !~ /^[0123456789]+$/{
+   print("Line >>", $NF, "<< does not have a valid revision number, skipping") > "/dev/stderr"
+   next
+}
+{
+   "datediff -f %d " today " " $2 | getline daysTilExpires
+   if (daysTilExpires <= 1) {
+       data=sprintf("{\042name\042:\042%s\042,\042revision\042:%d,\042channels\042:[\042%s\042]}", $1, $NF, $(NF-1))
+       system("surl -a " $1 " -s production -d '" data "'" FS url)
+   }
+}


### PR DESCRIPTION
If the maintainer ignores the warnings, the bot takes things in its own hands and attempts to refresh the snap's channel.

This commit puts commit 377d157434dc0b172f15b7a30b5d9973c3b7ffd9 into action.